### PR TITLE
fix: only run deploy action on master push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,8 @@
 name: Build and Deploy
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest


### PR DESCRIPTION
These changes implement only running the github deploy action on a push to the `master` branch instead of a push to any branch on the remote.